### PR TITLE
DEVICE-23 - Add new properties to `automox_device`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 1.2.0 - 2023-05-16
+
 ### Added
 
 - `automox_device` entities now have the following new properties:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `automox_device` entities now have the following new properties:
+
+  | Property       | Type       |
+  | -------------- | ---------- |
+  | `displayName`  | `string`   |
+  | `serialNumber` | `string`   |
+  | `macAddress`   | `string[]` |
+  | `lastSeenOn`   | `number`   |
+
 ## 1.1.0 - 2023-02-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-automox",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A JupiterOne Integration for ingesting data of the Automox",
   "license": "MPL-2.0",
   "main": "src/index.js",

--- a/src/steps/devices/converter.ts
+++ b/src/steps/devices/converter.ts
@@ -12,6 +12,10 @@ export function getDeviceKey(id: string): string {
 }
 
 export function createDeviceEntity(device: AutomoxDevice): Entity {
+  const serialNumber = device.serial_number;
+  const lastSeenOn = parseTimePropertyValue(device.last_refresh_time);
+  const macAddresses = getMacAddresses(device);
+
   return createIntegrationEntity({
     entityData: {
       source: device,
@@ -20,6 +24,7 @@ export function createDeviceEntity(device: AutomoxDevice): Entity {
         _class: Entities.DEVICE._class,
         _key: getDeviceKey(device.id.toString()),
         id: device.id.toString(),
+        displayName: device.display_name,
         name: device.name,
         serverGroupId: device.server_group_id,
         organizationId: device.organization_id,
@@ -29,7 +34,9 @@ export function createDeviceEntity(device: AutomoxDevice): Entity {
         category: 'endpoint',
         make: device.name,
         model: device.detail.MODEL,
-        serial: device.serial_number,
+        serial: serialNumber,
+        serialNumber,
+        macAddress: macAddresses.length ? macAddresses : undefined,
         deviceId: device.uuid,
         osFamily: device.os_family,
         osName: device.os_name,
@@ -42,11 +49,16 @@ export function createDeviceEntity(device: AutomoxDevice): Entity {
           (policyStatus) => policyStatus.id,
         ),
         lastProcessedOn: parseTimePropertyValue(device.last_process_time),
-        lastRefreshedOn: parseTimePropertyValue(device.last_refresh_time),
+        lastRefreshedOn: lastSeenOn,
+        lastSeenOn,
         lastScanFailedOn: parseTimePropertyValue(device.last_scan_failed),
         createdOn: parseTimePropertyValue(device.create_time),
         updatedOn: parseTimePropertyValue(device.last_update_time),
       },
     },
   });
+}
+
+function getMacAddresses(device: AutomoxDevice) {
+  return (device.detail.NICS || []).map((v) => v.MAC);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export type AutomoxUser = {
 export type AutomoxDevice = {
   id: number;
   name: string;
+  display_name: string;
   server_group_id: number;
   organization_id: number;
   uuid: string;


### PR DESCRIPTION
- `automox_device` entities now have the following new properties:

  | Property       | Type       |
  | -------------- | ---------- |
  | `displayName`  | `string`   |
  | `serialNumber` | `string`   |
  | `macAddress`   | `string[]` |
  | `lastSeenOn`   | `number`   |